### PR TITLE
Develop

### DIFF
--- a/lib/make/getParsedValueFromBinaryExpression.js
+++ b/lib/make/getParsedValueFromBinaryExpression.js
@@ -14,7 +14,9 @@ function getParsedValueFromBinaryExpression(expressionPart) {
         return makeBinaryExpressionPart(expressionPart);
     }
     if (expressionPart.type === 'column_ref') {
-        return `$${expressionPart.column}`;
+        return `$${expressionPart.table ? expressionPart.table + '.' : ''}${
+            expressionPart.column
+        }`;
     }
     if (['single_quote_string', 'string'].includes(expressionPart.type)) {
         return expressionPart.value;

--- a/lib/make/makeQueryPart.js
+++ b/lib/make/makeQueryPart.js
@@ -142,10 +142,10 @@ function makeQueryPart(
             const likeVal = queryPart.right.value;
             const regexString = sqlStringToRegex(likeVal);
             // eslint-disable-next-line security/detect-non-literal-regexp
-            const regex = new RegExp(regexString, 'i');
+            // const regex = new RegExp(regexString, 'i');
             return {
                 [getColumnNameOrVal(queryPart.left)]: {
-                    $not: regex,
+                    $not: {$regex: regexString, $options: 'i'},
                 },
             };
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synatic/sql-to-mongo",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Convert SQL to mongo queries or aggregates",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synatic/sql-to-mongo",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Convert SQL to mongo queries or aggregates",
   "main": "index.js",
   "files": [

--- a/test/aggregateTests/aggregateTests.json
+++ b/test/aggregateTests/aggregateTests.json
@@ -1827,5 +1827,46 @@
         "films"
       ]
     }
+  },
+  {
+    "name": "Query:fix alias for sum",
+    "query": "select filmId,(f.filmId + f.`Rental Duration` + 2) as val from films f where id>1",
+    "type": "aggregate",
+    "output": {
+      "pipeline": [
+        {
+          "$project": {
+            "f": "$$ROOT"
+          }
+        },
+        {
+          "$match": {
+            "f.id": {
+              "$gt": 1
+            }
+          }
+        },
+        {
+          "$project": {
+            "filmId": "$f.filmId",
+            "val": {
+              "$add": [
+                {
+                  "$add": [
+                    "$f.filmId",
+                    "$f.Rental Duration"
+                  ]
+                },
+                2
+              ]
+            }
+          }
+        }
+
+      ],
+      "collections": [
+        "films"
+      ]
+    }
   }
 ]

--- a/test/queryTests/comparisonOperators.json
+++ b/test/queryTests/comparisonOperators.json
@@ -614,5 +614,24 @@
       }
 
     }
+  },
+  {
+    "name": "Comparison:NOT Like",
+    "query": "select * from films\nwhere Title not like 'Academy%'",
+    "output": {
+      "collection": "films",
+      "limit": 100,
+      "query": {
+        "Title": {
+          "$not": {
+            "$regex": "^Academy",
+            "$options": "i"
+          }
+        }
+
+
+      }
+
+    }
   }
 ]


### PR DESCRIPTION
Fixes
- NOT LIKE returning empty match condition
- Alias prefixing on expressions in select statement
```select filmId,(f.filmId + f.`Rental Duration` + 2) as val from films f where id>1```