### PR TITLE
remove trailing semicolons before parsing

### DIFF
--- a/lib/parseSQLtoAST.js
+++ b/lib/parseSQLtoAST.js
@@ -17,9 +17,13 @@ function parseSQLtoAST(sql, options = {}) {
         }
         throw new Error(`SQL object does not contain the required key "ast"`);
     }
+
     const parser = new Parser();
     /** @type {import('./types').TableColumnAst} */
     let parsedAST;
+    // Remove terminating semicolons, as the parser thinks it is part of the query
+    sql = sql.trim();
+    sql = sql.replace(/;+$/, '');
     try {
         // @ts-ignore
         parsedAST = parser.parse(sql, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synatic/sql-to-mongo",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Convert SQL to mongo queries or aggregates",
   "main": "index.js",
   "files": [

--- a/test/queryTests/queryTests.json
+++ b/test/queryTests/queryTests.json
@@ -8,6 +8,14 @@
     }
   },
   {
+    "name": "Query:With Semicolon Terminator",
+    "query": "select * from `films`;",
+    "output": {
+      "collection": "films",
+      "limit": 100
+    }
+  },
+  {
     "name": "Query:Fields",
     "query": "select Title,Description from `films`",
     "output": {


### PR DESCRIPTION
fixes [https://github.com/synatic/sql-to-mongo/issues/111](https://github.com/synatic/sql-to-mongo/issues/111 )